### PR TITLE
バトルテンプレートの表記をデュエルテンプレートに変更

### DIFF
--- a/en.json
+++ b/en.json
@@ -748,7 +748,7 @@
       "confirm3": "",
       "cancel": "Cancel",
       "trade": "Trade",
-      "expandBattleTemplate": "Expand Battle Template +1",
+      "expandDuelTemplate": "Expand Duel Template +1",
       "expandQuestTemplate": "Expand Quest Template +1"
     }
   },

--- a/ja.json
+++ b/ja.json
@@ -752,7 +752,7 @@
       "confirm3": "を獲得します。よろしいでしょうか",
       "cancel": "キャンセル",
       "trade": "交換",
-      "expandBattleTemplate": "バトルテンプレート拡張+1",
+      "expandDuelTemplate": "デュエルテンプレート拡張+1",
       "expandQuestTemplate": "クエストテンプレート拡張+1"
     }
   },

--- a/zh.json
+++ b/zh.json
@@ -747,7 +747,7 @@
       "confirm3": "",
       "cancel": "Cancel",
       "trade": "Trade",
-      "expandBattleTemplate": "Expand Battle Template +1",
+      "expandDuelTemplate": "Expand Duel Template +1",
       "expandQuestTemplate": "Expand Quest Template +1"
     }
   },


### PR DESCRIPTION
# 対応内容
デュエルテンプレートとバトルテンプレートで表記揺れがあったためデュエルテンプレートに統一